### PR TITLE
Avoid calling callback twice on errors

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -174,6 +174,7 @@ var instagram = function(spec, my) {
       }
 
       var req = https.request(options, function(res) {
+        var called = false;
         var body = '';
         res.setEncoding('utf8');
 
@@ -182,6 +183,8 @@ var instagram = function(spec, my) {
         });
 
         res.on('end', function() {
+          if (called) return;
+          called = true;
           var result;
           var limit = parseInt(res.headers['x-ratelimit-limit'], 10) || 0;
           var remaining = parseInt(res.headers['x-ratelimit-remaining'], 10) || 0;
@@ -199,6 +202,8 @@ var instagram = function(spec, my) {
       });
 
       req.on('error', function(err) {
+        if (called) return;
+        called = true;
         return handle_error(err, cb, retry);
       });
 


### PR DESCRIPTION
`ECONNRESET` errors are triggered in the on `error` event but the `end` event is also triggered so the `handle_error` callback is called twice.